### PR TITLE
Hotfix/phase tag

### DIFF
--- a/pymela/io/file_formats.py
+++ b/pymela/io/file_formats.py
@@ -17,12 +17,12 @@ def getTwoPointFileNameASCII(phM,t0Tag,src,snk,srow,mFTag,nvec):
         return FileName
 #--------------------------
 
-def getTwoPointDirASCII(mainDir,t0Tag,mFTag):
-        return '%s/%s/%s' % (mainDir,t0Tag,mFTag)
+def getTwoPointDirASCII(mainDir,phDir,t0Tag,mFTag):
+        return '%s/%s/%s/%s' % (mainDir,phDir,t0Tag,mFTag)
 #--------------------------
 
-def getThreePointDirASCII(mainDir,t0Tag,tsepTag,mFTag):
-    return '%s/%s/%s/%s' % (mainDir,t0Tag,mFTag,tsepTag)
+def getThreePointDirASCII(mainDir,phDir,t0Tag,tsepTag,mFTag):
+    return '%s/%s/%s/%s/%s' % (mainDir,phDir,t0Tag,mFTag,tsepTag)
 #--------------------------
 
 def getThreePointFileNameASCII(phM,t0Tag,tsepTag,srcOp,snkOp,row,insOp,insRow,mFTag,dispTag,nvec):

--- a/pymela/io/io_conventions.py
+++ b/pymela/io/io_conventions.py
@@ -30,17 +30,17 @@ inputInfoTags = {'2pt analysis': [analysisInfoTag, c2ptDataInfoTag, ensembleInfo
 # What is expected in each object of the JSON input file
 expectedKeys = {c2ptDataInfoTag:  ['Data Main Directory', 'Datasets', 'Data Source', 'Write HDF5 Output'],
                 c3ptDataInfoTag:  ['Data Main Directory', 'Datasets', 'Insertion Operators', 'Data Source', 'Write HDF5 Output'],
-                analysisInfoTag:  ['Phasing Tag', 'Nvec', 'Binsize'],
+                analysisInfoTag:  ['Nvec', 'Binsize'],
                 ensembleInfoTag:  ['Tag', 'L', 'T', 'alat fm', 'mpi GeV', 'mN GeV'],
                 effEnergyInfoTag: ['HDF5 Output File', 'Fitting'],
                 ratioInfoTag    : ['Write HDF5 Output'],
                 ratioFitInfoTag : [],
                 ITDInfoTag: ['HDF5 Output File','Optimal Fits']}
 
-expectedSubKeys = {c2ptDataInfoTag: {'Datasets': ['Mom List', 'Ncfg', 't0','Nt','Interpolating Operators File',
+expectedSubKeys = {c2ptDataInfoTag: {'Datasets': ['Mom List', 'Phase Info', 'Ncfg', 't0','Nt','Interpolating Operators File',
                                                   'Nrows','Compute X-rows']
                                     },
-                   c3ptDataInfoTag: {'Datasets': ['Mom List', 'Ncfg', 't0','tsep','disp','Interpolating Operators File',
+                   c3ptDataInfoTag: {'Datasets': ['Mom List', 'Phase Info', 'Ncfg', 't0','tsep','disp','Interpolating Operators File',
                                                   'Nrows','Compute X-rows']
                                     },                 
                    effEnergyInfoTag: {'Fitting': ['Type', 'Ranges']},

--- a/pymela/threepointcorr.py
+++ b/pymela/threepointcorr.py
@@ -74,7 +74,6 @@ class ThreePointCorrelator():
 
         # Fill in Attributes
         self.Nvec = self.analysisInfo['Nvec']
-        self.phaseTag = self.analysisInfo['Phasing Tag']
 
         # The list of insertion operators we are considering
         self.gammaList = self.dataInfo['Insertion Operators']
@@ -97,7 +96,7 @@ class ThreePointCorrelator():
 
                 self.moms.append(momVec)
 
-                for attr in ['t0','Ncfg','tsep','disp','Nrows','Compute X-rows']:
+                for attr in ['t0','Ncfg','tsep','disp','Nrows','Compute X-rows','Phase Info']:
                     self.dSetAttr[mTag][attr] = dSet[attr]
 
                 # Determine the values of z3 that we will average over
@@ -152,6 +151,17 @@ class ThreePointCorrelator():
                 dispList = self.dSetAttr[mTag]['disp']
                 Nrows = self.dSetAttr[mTag]['Nrows']
                 Ncfg = self.dSetAttr[mTag]['Ncfg']
+                phaseInfo = self.dSetAttr[mTag]['Phase Info']
+
+                # Determine phase tag based on momentum sign
+                if list(phaseInfo.keys())[0] == 'unphased':
+                    phFile = phaseInfo['unphased']
+                    phDir = 'unphased'
+                elif list(phaseInfo.keys())[0] == 'phased':
+                    phFile = phaseInfo['phased']['Plus'] if mom[2] >= 0 else phaseInfo['phased']['Minus']
+                    phDir = 'phased/' + phFile
+                else:
+                    raise ValueError('Supported Phase Tag keys are ["unphased","phased"]')
 
                 # Determine the Jackknife sampling number of Bins
                 self.Nbins = jackknife.Nbins(Ncfg,self.binsize)
@@ -164,7 +174,7 @@ class ThreePointCorrelator():
                     tsepTag = tags.tsep(tsep)
                     for t0 in t0List:
                         t0Tag = tags.t0(t0)
-                        fileDir = ioForm.getThreePointDirASCII(self.dataInfo['Data Main Directory'],t0Tag,tsepTag,mFTag)
+                        fileDir = ioForm.getThreePointDirASCII(self.dataInfo['Data Main Directory'],phDir,t0Tag,tsepTag,mFTag)
                         print('Reading three-point data for momentum %s, tsep = %d, t0 = %d'%(mTag,tsep,t0))
                         for z3 in dispList:
                             dispTag = tags.disp(z3)
@@ -178,7 +188,7 @@ class ThreePointCorrelator():
                                         # Determine gamma matrix name and row
                                         insOp,insRow = gmat.insertionMap(gamma)
 
-                                        fileName = ioForm.getThreePointFileNameASCII(self.phaseTag,t0Tag,tsepTag,
+                                        fileName = ioForm.getThreePointFileNameASCII(phFile,t0Tag,tsepTag,
                                                                                      srcOp,snkOp,row,insOp,insRow,
                                                                                      mFTag,dispTag,self.Nvec)
                                         fileRead = '%s/%s'%(fileDir,fileName)


### PR DESCRIPTION
Improved handling of Phasing information when reading data for two- and three-point functions.
- Phase labels now passed as arguments in functions that return the directories of the data files.
- Take into account the different phase labels in filenames for data from un-phased and phased runs.